### PR TITLE
Fix URL encoding

### DIFF
--- a/phpbash.php
+++ b/phpbash.php
@@ -168,7 +168,7 @@
 
                 request.open("POST", "", true);
                 request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-                request.send("cmd="+command);
+                request.send("cmd="+encodeURIComponent(command));
                 return false;
             }
             


### PR DESCRIPTION
This is needed for commands like "chmod +x..." to work correctly